### PR TITLE
Disable addon for `ember test`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ module.exports = {
   name: 'qunit-console-grouper',
 
   isEnabled() {
+    // support `QUNIT_CONSOLE_GROUPER` environment variable: true/false
+    if (process.env.QUNIT_CONSOLE_GROUPER) {
+      return process.env.QUNIT_CONSOLE_GROUPER === 'true';
+    }
+
     if (process.env.EMBER_CLI_TEST_COMMAND === 'true') {
       // disable this addon for `ember test`, but not `ember test --server`
       return (

--- a/index.js
+++ b/index.js
@@ -6,6 +6,21 @@ const Funnel = require('broccoli-funnel');
 module.exports = {
   name: 'qunit-console-grouper',
 
+  isEnabled() {
+    if (process.env.EMBER_CLI_TEST_COMMAND === 'true') {
+      // disable this addon for `ember test`, but not `ember test --server`
+      return (
+        process.argv.includes('--server') ||
+        process.argv.includes('-server') ||
+        process.argv.includes('--serve') ||
+        process.argv.includes('-serve') ||
+        process.argv.includes('-s')
+      );
+    }
+
+    return true;
+  },
+
   included() {
     this._super.included.apply(this, arguments);
     this.import('vendor/qunit-console-grouper.js', { type: 'test' });


### PR DESCRIPTION
Newer versions of `testem` now output `console.group()` calls too, which is causing a noisy output when run via `ember test`. For `ember test --server` the grouping might still be valuable. The new logic is:

- If `QUNIT_CONSOLE_GROUPER` is set to `true` the addon is unconditionally enabled
- If `QUNIT_CONSOLE_GROUPER` is set to `false` the addon is unconditionally disabled
- If `ember test` is used, the addon will only be enabled if `--server` (or similar aliases) are being used
- otherwise the addon will by enabled by default

Resolves #9 